### PR TITLE
Compatibility with latest dependabot & gitea versions

### DIFF
--- a/lib/hack/dependabot-core/common/lib/dependabot/clients/gitea.rb
+++ b/lib/hack/dependabot-core/common/lib/dependabot/clients/gitea.rb
@@ -129,13 +129,14 @@ module Dependabot
       def post(url, json)
         response = Excon.post(
           url,
-          headers: {
-            "Content-Type" => "application/json"
-          },
           body: json,
           query: {access_token: credentials&.fetch("password")},
           idempotent: true,
-          **SharedHelpers.excon_defaults
+          **SharedHelpers.excon_defaults(
+            headers: {
+                "Content-Type" => "application/json"
+              }
+          )
         )
         raise NotFound if response.status == 404
 
@@ -145,13 +146,14 @@ module Dependabot
       def put(url, json)
         response = Excon.put(
           url,
-          headers: {
-            "Content-Type" => "application/json"
-          },
           body: json,
           query: {access_token: credentials&.fetch("password")},
           idempotent: true,
-          **SharedHelpers.excon_defaults
+          **SharedHelpers.excon_defaults(
+            headers: {
+                "Content-Type" => "application/json"
+              }
+          )
         )
         raise NotFound if response.status == 404
 

--- a/lib/hack/dependabot-core/common/lib/dependabot/pull_request_creator.rb
+++ b/lib/hack/dependabot-core/common/lib/dependabot/pull_request_creator.rb
@@ -15,8 +15,9 @@ module Dependabot
       when "github" then github_creator.create
       when "gitlab" then gitlab_creator.create
       when "azure" then azure_creator.create
-      when "gitea" then gitea_creator.create
+      when "bitbucket" then bitbucket_creator.create
       when "codecommit" then codecommit_creator.create
+      when "gitea" then gitea_creator.create
       else raise "Unsupported provider #{source.provider}"
       end
     end
@@ -28,9 +29,9 @@ module Dependabot
         base_commit: base_commit,
         credentials: credentials,
         files: files,
-        commit_message: message_builder.commit_message,
-        pr_description: message_builder.pr_message,
-        pr_name: message_builder.pr_name,
+        commit_message: message.commit_message,
+        pr_description: message.pr_message,
+        pr_name: message.pr_name,
         author_details: author_details,
         labeler: labeler
       )

--- a/lib/hack/dependabot-core/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
+++ b/lib/hack/dependabot-core/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
@@ -11,8 +11,9 @@ module Dependabot
         when "github" then recent_github_commit_messages
         when "gitlab" then recent_gitlab_commit_messages
         when "azure" then recent_azure_commit_messages
-        when "gitea" then recent_gitea_commit_messages
+        when "bitbucket" then recent_bitbucket_commit_messages
         when "codecommit" then recent_codecommit_commit_messages
+        when "gitea" then recent_gitea_commit_messages
         else raise "Unsupported provider: #{source.provider}"
         end
       end
@@ -34,6 +35,7 @@ module Dependabot
           when "gitlab" then last_gitlab_dependabot_commit_message
           when "azure" then last_azure_dependabot_commit_message
           when "gitea" then last_gitea_dependabot_commit_message
+          when "bitbucket" then last_bitbucket_dependabot_commit_message
           when "codecommit" then last_codecommit_dependabot_commit_message
           else raise "Unsupported provider: #{source.provider}"
           end


### PR DESCRIPTION
Hi !

I'm not a ruby developer, but I tried to debug issues I got with my dependabot runner for some time (I didn't have PRs for few months now). I edited libs on my computer and tested them, and now it works with latest dependabot-core version (0.174.0) and gitea 1.15.10 without any problem.

Could you review my PR and update the gem when you have some time ? Then I'll notify https://hub.docker.com/r/xefir/docker-dependabot-gitea developers that they could update their image, so we can use their image as before :)

Thanks !